### PR TITLE
fix(Undefined offset issue when running phpcbf commmand)

### DIFF
--- a/src/CrazyFactory/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/CrazyFactory/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -229,6 +229,11 @@ class ControlSignatureSniff implements Sniff
             break;
         }//end for
 
+        // Prevent undefined offset error
+        // This occur when character after closing brace is white space
+        if($next >= $phpcsFile->numTokens) {
+            return;
+        }
 
         if ($tokens[$next]['line'] === $tokens[$brace]['line']) {
             $error = 'Newline required after ' . $braceMsg;


### PR DESCRIPTION
This error will occur when brace is before the last character of the file and last character is white space or new line. Issue #12