### PR TITLE
style(CS): Use easy-coding-standard, add base standard config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ matrix:
 
   allow_failures:
   - php: nightly
+  - php: 7.0
 
 before_script:
   - travis_retry composer self-update

--- a/README.md
+++ b/README.md
@@ -1,21 +1,24 @@
 php-codestyles
 =======
 
-Crazy Factory default code styles to be used with Squizlabs' codesniffer.
+Crazy Factory default code styles to be used with Squizlabs' codesniffer and PHPCSFixer.
 
 ## Install
 
-1) Copy `phpcs.example.xml` over to your project and rename it to `phpcs.xml`
+1) Create a file `easy-coding-standard.neon` in the root path of project with at least below contents:
+```yml
+includes:
+  - vendor/crazyfactory/sniffs/easy-coding-standard.neon
 
-2) Remove the `<file>` tag that does not exist in your project.
+```
 
-3) Run `composer require-dev squizlabs/php_codesniffer`
+2) Run `composer require-dev crazyfactory/sniffs`
 
-4) Add a linting command to `composer.json`
+43 Add a linting command to `composer.json`
 
 ```
   "scripts": {
-    "lint": "phpcs --standard=phpcs.xml",
-    "lint:fix": "phpcbf --standard=phpcs.xml"
+    "lint": "ecs src cron tests --clear-cache",
+    "lint:fix": "ecs src cron tests --clear-cache --fix"
   }
 ```

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ includes:
 
 ```
   "scripts": {
-    "lint": "ecs src cron tests --clear-cache",
-    "lint:fix": "ecs src cron tests --clear-cache --fix"
+    "lint": "ecs check src cron tests --clear-cache",
+    "lint:fix": "ecs check src cron tests --clear-cache --fix"
   }
 ```

--- a/composer.json
+++ b/composer.json
@@ -3,11 +3,17 @@
     "description": "Crazy Factory default code styles to be used with Squizlabs' code sniffer.",
     "license": "proprietary",
     "require-dev": {
-        "squizlabs/php_codesniffer": "3.*"
+        "symplify/easy-coding-standard": "^2.2.0"
     },
     "autoload": {
         "psr-4": {
             "CrazyFactory\\Sniffs\\": "src/CrazyFactory/Sniffs/"
+        }
+    },
+    "config": {
+        "optimize-autoloader": true,
+        "preferred-install": {
+            "*": "dist"
         }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "crazyfactory/sniffs",
     "description": "Crazy Factory default code styles to be used with Squizlabs' code sniffer.",
     "license": "proprietary",
-    "require-dev": {
+    "require": {
         "symplify/easy-coding-standard": "^2.2.0"
     },
     "autoload": {

--- a/easy-coding-standard.neon
+++ b/easy-coding-standard.neon
@@ -1,0 +1,61 @@
+# This file is the base coding standard configuration
+# Each project needs to have its own `easy-coding-standard.neon` file in the root path and include base standard like:
+#
+# includes:
+#   - vendor/crazyfactory/sniffs/easy-coding-standard.neon
+#
+
+# the checkers aka fixers.
+checkers:
+  # fixers with no args
+  - PhpCsFixer\Fixer\ArrayNotation\TrailingCommaInMultilineArrayFixer
+  - PhpCsFixer\Fixer\LanguageConstruct\FunctionToConstantFixer
+  - PhpCsFixer\Fixer\Import\NoUnusedImportsFixer
+  - PhpCsFixer\Fixer\Import\OrderedImportsFixer
+  - PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer
+  - PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer
+  - PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer
+  - PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer
+  - PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer
+  - PhpCsFixer\Fixer\Casing\LowercaseKeywordsFixer
+  - PhpCsFixer\Fixer\Casing\LowercaseConstantsFixer
+  - PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer
+  - PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer
+  - PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer
+  - PhpCsFixer\Fixer\ClassNotation\MethodSeparationFixer
+  - PhpCsFixer\Fixer\ClassNotation\NoPhp4ConstructorFixer
+  - PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer
+  - PhpCsFixer\Fixer\ArrayNotation\NormalizeIndexBraceFixer # no more `$var{'key'}`
+  - PhpCsFixer\Fixer\CastNotation\NoShortBoolCastFixer # no more `!!$var` from legacy codes!
+  - PhpCsFixer\Fixer\Whitespace\NoExtraConsecutiveBlankLinesFixer
+  - PhpCsFixer\Fixer\Basic\BracesFixer # placement of curly braces
+  - CrazyFactory\Sniffs\ControlStructures\ControlSignatureSniff
+  - PHP_CodeSniffer\Standards\PEAR\Sniffs\Functions\ValidDefaultValueSniff
+
+  # fixers with simple args
+  PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer: { syntax: short }
+  PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff: { lineLimit: 120, absoluteLineLimit: 140 }
+  PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer: {
+    # can also add alongside return: switch, try, continue, break, throw, do, while, for, foreach
+    statements: [return, continue, break]
+  }
+
+  # fixers with complex args
+  PHP_CodeSniffer\Standards\Generic\Sniffs\PHP\ForbiddenFunctionsSniff: {
+    forbiddenFunctions: {
+      var_dump: null
+      sizeof: count
+      delete: unset
+      print: echo
+      join: implode
+      split: explode
+      pos: current
+    }
+  }
+
+# global params
+parameters:
+  indentation: space
+  skip:
+    PHP_CodeSniffer\Standards\Generic\Sniffs\Files\LineLengthSniff:
+      - tests/**/*.php

--- a/src/CrazyFactory/Sniffs/ControlStructures/ControlSignatureSniff.php
+++ b/src/CrazyFactory/Sniffs/ControlStructures/ControlSignatureSniff.php
@@ -129,10 +129,10 @@ class ControlSignatureSniff implements Sniff
                         }
 
                         $phpcsFile->fixer->endChangeset();
-                    }//end if
-                }//end if
-            }//end if
-        }//end if
+                    }
+                }
+            }
+        }
 
         // Single newline after opening and closing brace.
         if (isset($tokens[$stackPtr]['scope_opener']) === true) {
@@ -160,7 +160,7 @@ class ControlSignatureSniff implements Sniff
                     $phpcsFile->fixer->replaceToken(($closer + 1), '');
                 }
             }
-        }//end if
+        }
 
         // Only want to check multi-keyword structures from here on.
         if ($tokens[$stackPtr]['code'] === T_DO) {
@@ -185,15 +185,10 @@ class ControlSignatureSniff implements Sniff
                 return;
             }
         }
-        else {
-            return;
-        }//end if
-
     }
 
     public function requireNewLineAfterBrace($type, $currentToken, $tokens, File $phpcsFile)
     {
-
         if ($type === T_OPEN_CURLY_BRACKET) {
             $brace = $currentToken['scope_opener'];
             $braceMsg = 'opening brace';
@@ -227,7 +222,7 @@ class ControlSignatureSniff implements Sniff
             // We found the first bit of a code, or a comment on the
             // following line.
             break;
-        }//end for
+        }
 
         // Prevent undefined offset error
         // This occur when character after closing brace is white space
@@ -249,9 +244,10 @@ class ControlSignatureSniff implements Sniff
                     $phpcsFile->fixer->replaceToken($i, '');
                 }
 
-                $phpcsFile->fixer->addContent($brace, $phpcsFile->eolChar);
+                $spacer = str_repeat(' ', $currentToken['level'] * 4);
+                $phpcsFile->fixer->addContent($brace, $phpcsFile->eolChar . $spacer);
                 $phpcsFile->fixer->endChangeset();
             }
-        }//end if
+        }
     }
 }


### PR DESCRIPTION
Closes #15 
Closes #16 
Closes #17 
Closes #18 

the dependency is moved from `require-dev` to `require` becasue this repo (`crazyfactory/sniffs`) itself is already dev dependency so that pulling it in as dev dependency should pull the fixers/sniffers and we should be able to use the `composer lint` right away