### PR TITLE
fix(ruleset.xml)

### DIFF
--- a/src/CrazyFactory/ruleset.xml
+++ b/src/CrazyFactory/ruleset.xml
@@ -38,6 +38,7 @@
     <rule ref="Squiz.Strings.ConcatenationSpacing">
         <properties>
             <property name="spacing" value="1" />
+            <property name="ignoreNewlines" value="true" />
         </properties>
     </rule>
 


### PR DESCRIPTION
Allow newline for string concatenation spacing.

closes #28 