### PR TITLE
fix(BlankLineBeforeReturnSniff)

### DIFF
--- a/src/CrazyFactory/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
+++ b/src/CrazyFactory/Sniffs/Formatting/BlankLineBeforeReturnSniff.php
@@ -62,6 +62,8 @@ class BlankLineBeforeReturnSniff implements Sniff
 
         if (isset($prevLineTokens[0])
             && ($prevLineTokens[0] == 'T_OPEN_CURLY_BRACKET' || $prevLineTokens[0] == 'T_DOC_COMMENT_CLOSE_TAG')
+            || in_array('T_CASE', $prevLineTokens)
+            || in_array('T_DEFAULT', $prevLineTokens)
         ) {
             return;
         }


### PR DESCRIPTION
Do not enforce blank line when previous line is "case" or "default".

closes #30 