### PR TITLE
fix: wrong namespace in config ruleset file

### DIFF
--- a/src/CrazyFactory/ruleset.xml
+++ b/src/CrazyFactory/ruleset.xml
@@ -16,7 +16,7 @@
     <rule ref="Squiz.Arrays.ArrayBracketSpacing"/>
 
     <!-- Long lines do no apply on test files -->
-    <rule ref="Generic.Files.LineLength.TooLong">
+    <rule ref="Generic.Files.LineLength">
         <exclude-pattern>./tests/*</exclude-pattern>
         <properties>
             <property name="lineLimit" value="140" />


### PR DESCRIPTION
Line length setting never work because of wrong namespace.