### PR TITLE
fix: namespace alias is accidently deleted during lint:fix

### DIFF
--- a/src/CrazyFactory/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/src/CrazyFactory/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -141,7 +141,7 @@ class UseInAlphabeticalOrderSniff implements Sniff
         $end = $phpcsFile->findNext([T_SEMICOLON, T_OPEN_CURLY_BRACKET], $stackPtr);
         $useTokens = array_slice($tokens, $stackPtr, $end - $stackPtr, true);
         foreach ($useTokens as $index => $token) {
-            if ($token['code'] === T_STRING || $token['code'] === T_NS_SEPARATOR) {
+            if (in_array($token['code'], [T_STRING, T_NS_SEPARATOR, T_WHITESPACE, T_AS])) {
                 $content .= $token['content'];
             }
         }

--- a/src/CrazyFactory/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
+++ b/src/CrazyFactory/Sniffs/Formatting/UseInAlphabeticalOrderSniff.php
@@ -104,7 +104,7 @@ class UseInAlphabeticalOrderSniff implements Sniff
                 // Insert new use statements
                 $usePos = $phpcsFile->findNext(T_USE, $stackPtr);
                 foreach ($sorted as $name) {
-                    $phpcsFile->fixer->addContent($usePos, " {$name};");
+                    $phpcsFile->fixer->addContent($usePos, "{$name};");
                     $usePos = $phpcsFile->findNext(T_USE, $usePos + 1);
                 }
 

--- a/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.1.inc
+++ b/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.1.inc
@@ -6,3 +6,4 @@ use B\Bat;
 use A\Bat;
 use A\Cat;
 use A\Ant;
+use A\Ant as Z;

--- a/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.1.inc.fixed
+++ b/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.1.inc.fixed
@@ -1,6 +1,7 @@
 <?php
 
 use A\Ant;
+use A\Ant as Z;
 use A\Bat;
 use A\Cat;
 use B\Ant;

--- a/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.php
+++ b/src/CrazyFactory/Tests/Formatting/UseInAlphabeticalOrderUnitTest.php
@@ -19,7 +19,7 @@ class UseInAlphabeticalOrderUnitTest extends AbstractSniffUnitTest
         switch ($testFile) {
             case 'UseInAlphabeticalOrderUnitTest.1.inc':
                 return [
-                    2 => 6
+                    2 => 7
                 ];
                 break;
             case 'UseInAlphabeticalOrderUnitTest.2.inc':


### PR DESCRIPTION
closes crazyfactory/php-sniffs#44 	